### PR TITLE
Imgrush support

### DIFF
--- a/gfy_mirror/bot.py
+++ b/gfy_mirror/bot.py
@@ -14,7 +14,7 @@ import praw.helpers
 import signal
 import psycopg2
 from utils import log, Color, retrieve_vine_video_url, gfycat_convert, get_id, mediacrush_convert, get_gfycat_info, \
-    fitbamob_convert, imgur_upload, get_fitbamob_info, notify_mac, retrieve_vine_cdn_url
+    offsided_convert, imgur_upload, get_offsided_info, notify_mac, retrieve_vine_cdn_url
 
 __author__ = 'Henri Sweers'
 
@@ -46,7 +46,7 @@ allowedDomains = [
         "zippy.gfycat.com",
         "fat.gfycat.com",
         "mediacru.sh",
-        "fitbamob.com",
+        "offsided.com",
         "i.imgur.com",
         "v.cdn.vine.co",
         "giffer.co"]
@@ -78,7 +78,7 @@ class MirroredObject():
     original_url = None
     gfycat_url = None
     mediacrush_url = None
-    fitbamob_url = None
+    offsided_url = None
     imgur_url = None
 
     def __init__(self, op_id, original_url, json_data=None):
@@ -109,14 +109,14 @@ class MirroredObject():
             if "gfycat" not in self.original_url:
                 s += " - [gif](%s)" % self.mc_url("gif", mc_id)
             s += " - [ogg](%s)" % self.mc_url("ogv", mc_id)
-        if self.fitbamob_url:
+        if self.offsided_url:
             s += "\n\n"
-            s += "* [Fitbamob](%s)" % self.fitbamob_url
+            s += "* [Offsided](%s)" % self.offsided_url
             # TODO Re-enable this when possible
-            # fit_id = get_id(self.fitbamob_url)
-            # urls = self.fitbamob_urls(fit_id)
-            # s += "* [Fitbamob](%s) | [mp4](%s) - [webm](%s) - [gif](%s)" % (
-            #     self.fitbamob_url, urls[0], urls[1], urls[2])
+            # fit_id = get_id(self.offsided_url)
+            # urls = self.offsided_urls(fit_id)
+            # s += "* [Offsided](%s) | [mp4](%s) - [webm](%s) - [gif](%s)" % (
+            #     self.offsided_url, urls[0], urls[1], urls[2])
         if self.imgur_url:
             s += "\n\n"
             s += "* [Imgur](%s) (gif only)" % self.imgur_url
@@ -130,8 +130,8 @@ class MirroredObject():
         info = get_gfycat_info(gfy_id)
         return info['mp4Url'], info['webmUrl'], info['gifUrl']
 
-    def fitbamob_urls(self, fit_id):
-        info = get_fitbamob_info(fit_id)['source']
+    def offsided_urls(self, fit_id):
+        info = get_offsided_info(fit_id)['source']
         return info['mp4_url'], info['webm_url'], info['gif_url']
 
     def mc_url(self, media_type, mc_id):
@@ -296,9 +296,9 @@ def process_submission(submission):
     elif submission.domain == "mediacru.sh":
         new_mirror.mediacrush_url = url_to_process
         url_to_process = "https://cdn.mediacru.sh/%s.mp4" % get_id(url_to_process)
-    elif submission.domain == "fitbamob.com":
-        new_mirror.fitbamob_url = url_to_process
-        url_to_process = get_fitbamob_info(get_id(url_to_process))['mp4_url']
+    elif submission.domain == "offsided.com":
+        new_mirror.offsided_url = url_to_process
+        url_to_process = get_offsided_info(get_id(url_to_process))['mp4_url']
 
     if submission.domain == "giant.gfycat.com":
         # Just get the gfycat url
@@ -326,11 +326,11 @@ def process_submission(submission):
         new_mirror.mediacrush_url = mediacrush_convert(url_to_process)
         log("--MC url is " + new_mirror.mediacrush_url)
 
-    if submission.domain != "fitbamob.com":
-        fitba_url = fitbamob_convert(submission.title, url_to_process)
+    if submission.domain != "offsided.com":
+        fitba_url = offsided_convert(submission.title, url_to_process)
         if fitba_url:
-            new_mirror.fitbamob_url = fitba_url
-            log("--Fitbamob url is " + new_mirror.fitbamob_url)
+            new_mirror.offsided_url = fitba_url
+            log("--Offsided url is " + new_mirror.offsided_url)
 
     # TODO Re-enable this once "animated = false" issue resolved
     # if not already_imgur:

--- a/gfy_mirror/bot.py
+++ b/gfy_mirror/bot.py
@@ -13,7 +13,7 @@ import praw
 import praw.helpers
 import signal
 import psycopg2
-from utils import log, Color, retrieve_vine_video_url, gfycat_convert, get_id, mediacrush_convert, get_gfycat_info, \
+from utils import log, Color, retrieve_vine_video_url, gfycat_convert, get_id, imgrush_convert, get_gfycat_info, \
     offsided_convert, imgur_upload, get_offsided_info, notify_mac, retrieve_vine_cdn_url
 
 __author__ = 'Henri Sweers'
@@ -45,7 +45,7 @@ allowedDomains = [
         "giant.gfycat.com",
         "zippy.gfycat.com",
         "fat.gfycat.com",
-        "mediacru.sh",
+        "imgrush.com",
         "offsided.com",
         "i.imgur.com",
         "v.cdn.vine.co",
@@ -77,7 +77,7 @@ class MirroredObject():
     op_id = None
     original_url = None
     gfycat_url = None
-    mediacrush_url = None
+    imgrush_url = None
     offsided_url = None
     imgur_url = None
 
@@ -100,10 +100,10 @@ class MirroredObject():
             s += "\n\n"
             s += "* [Gfycat](%s) | [mp4](%s) - [webm](%s) - [gif](%s)" % (
                 self.gfycat_url, urls[0], urls[1], urls[2])
-        if self.mediacrush_url:
+        if self.imgrush_url:
             s += "\n\n"
-            mc_id = get_id(self.mediacrush_url)
-            s += "* [Mediacrush](%s) | " % self.mediacrush_url
+            mc_id = get_id(self.imgrush_url)
+            s += "* [Imgrush](%s) | " % self.imgrush_url
             s += "[mp4](%s)" % self.mc_url("mp4", mc_id)
             s += " - [webm](%s)" % self.mc_url("webm", mc_id)
             if "gfycat" not in self.original_url:
@@ -135,7 +135,7 @@ class MirroredObject():
         return info['mp4_url'], info['webm_url'], info['gif_url']
 
     def mc_url(self, media_type, mc_id):
-        return "https://cdn.mediacru.sh/%s.%s" % (mc_id, media_type)
+        return "https://imgrush.com/%s.%s" % (mc_id, media_type)
 
 
 # Called when exiting the program
@@ -293,9 +293,9 @@ def process_submission(submission):
         already_gfycat = True
         new_mirror.gfycat_url = url_to_process
         url_to_process = get_gfycat_info(get_id(url_to_process))['mp4Url']
-    elif submission.domain == "mediacru.sh":
-        new_mirror.mediacrush_url = url_to_process
-        url_to_process = "https://cdn.mediacru.sh/%s.mp4" % get_id(url_to_process)
+    elif submission.domain == "imgrush.com":
+        new_mirror.imgrush_url = url_to_process
+        url_to_process = "https://imgrush.com/%s.mp4" % get_id(url_to_process)
     elif submission.domain == "offsided.com":
         new_mirror.offsided_url = url_to_process
         url_to_process = get_offsided_info(get_id(url_to_process))['mp4_url']
@@ -321,10 +321,10 @@ def process_submission(submission):
             cache_submission(submission)
             return
 
-    if submission.domain != "mediacru.sh":
+    if submission.domain != "imgrush.com":
         # TODO check file size limit (50 mb)
-        new_mirror.mediacrush_url = mediacrush_convert(url_to_process)
-        log("--MC url is " + new_mirror.mediacrush_url)
+        new_mirror.imgrush_url = imgrush_convert(url_to_process)
+        log("--MC url is " + new_mirror.imgrush_url)
 
     if submission.domain != "offsided.com":
         fitba_url = offsided_convert(submission.title, url_to_process)

--- a/gfy_mirror/bot.py
+++ b/gfy_mirror/bot.py
@@ -13,7 +13,7 @@ import praw
 import praw.helpers
 import signal
 import psycopg2
-from utils import log, Color, retrieve_vine_video_url, gfycat_convert, get_id, get_gfycat_info, \
+from utils import log, Color, retrieve_vine_video_url, gfycat_convert, get_id, mediacrush_convert, get_gfycat_info, \
     fitbamob_convert, imgur_upload, get_fitbamob_info, notify_mac, retrieve_vine_cdn_url
 
 __author__ = 'Henri Sweers'
@@ -45,7 +45,7 @@ allowedDomains = [
         "giant.gfycat.com",
         "zippy.gfycat.com",
         "fat.gfycat.com",
-        # "mediacru.sh",
+        "mediacru.sh",
         "fitbamob.com",
         "i.imgur.com",
         "v.cdn.vine.co",
@@ -77,7 +77,7 @@ class MirroredObject():
     op_id = None
     original_url = None
     gfycat_url = None
-    # mediacrush_url = None
+    mediacrush_url = None
     fitbamob_url = None
     imgur_url = None
 
@@ -100,15 +100,15 @@ class MirroredObject():
             s += "\n\n"
             s += "* [Gfycat](%s) | [mp4](%s) - [webm](%s) - [gif](%s)" % (
                 self.gfycat_url, urls[0], urls[1], urls[2])
-        # if self.mediacrush_url:
-        #     s += "\n\n"
-        #     mc_id = get_id(self.mediacrush_url)
-        #     s += "* [Mediacrush](%s) | " % self.mediacrush_url
-        #     s += "[mp4](%s)" % self.mc_url("mp4", mc_id)
-        #     s += " - [webm](%s)" % self.mc_url("webm", mc_id)
-        #     if "gfycat" not in self.original_url:
-        #         s += " - [gif](%s)" % self.mc_url("gif", mc_id)
-        #     s += " - [ogg](%s)" % self.mc_url("ogv", mc_id)
+        if self.mediacrush_url:
+            s += "\n\n"
+            mc_id = get_id(self.mediacrush_url)
+            s += "* [Mediacrush](%s) | " % self.mediacrush_url
+            s += "[mp4](%s)" % self.mc_url("mp4", mc_id)
+            s += " - [webm](%s)" % self.mc_url("webm", mc_id)
+            if "gfycat" not in self.original_url:
+                s += " - [gif](%s)" % self.mc_url("gif", mc_id)
+            s += " - [ogg](%s)" % self.mc_url("ogv", mc_id)
         if self.fitbamob_url:
             s += "\n\n"
             s += "* [Fitbamob](%s)" % self.fitbamob_url
@@ -134,8 +134,8 @@ class MirroredObject():
         info = get_fitbamob_info(fit_id)['source']
         return info['mp4_url'], info['webm_url'], info['gif_url']
 
-    # def mc_url(self, media_type, mc_id):
-    #     return "https://cdn.mediacru.sh/%s.%s" % (mc_id, media_type)
+    def mc_url(self, media_type, mc_id):
+        return "https://cdn.mediacru.sh/%s.%s" % (mc_id, media_type)
 
 
 # Called when exiting the program
@@ -293,9 +293,9 @@ def process_submission(submission):
         already_gfycat = True
         new_mirror.gfycat_url = url_to_process
         url_to_process = get_gfycat_info(get_id(url_to_process))['mp4Url']
-    # elif submission.domain == "mediacru.sh":
-    #     new_mirror.mediacrush_url = url_to_process
-    #     url_to_process = "https://cdn.mediacru.sh/%s.mp4" % get_id(url_to_process)
+    elif submission.domain == "mediacru.sh":
+        new_mirror.mediacrush_url = url_to_process
+        url_to_process = "https://cdn.mediacru.sh/%s.mp4" % get_id(url_to_process)
     elif submission.domain == "fitbamob.com":
         new_mirror.fitbamob_url = url_to_process
         url_to_process = get_fitbamob_info(get_id(url_to_process))['mp4_url']
@@ -321,10 +321,10 @@ def process_submission(submission):
             cache_submission(submission)
             return
 
-    # if submission.domain != "mediacru.sh":
-    #     # TODO check file size limit (50 mb)
-    #     new_mirror.mediacrush_url = mediacrush_convert(url_to_process)
-    #     log("--MC url is " + new_mirror.mediacrush_url)
+    if submission.domain != "mediacru.sh":
+        # TODO check file size limit (50 mb)
+        new_mirror.mediacrush_url = mediacrush_convert(url_to_process)
+        log("--MC url is " + new_mirror.mediacrush_url)
 
     if submission.domain != "fitbamob.com":
         fitba_url = fitbamob_convert(submission.title, url_to_process)

--- a/gfy_mirror/pycrush.py
+++ b/gfy_mirror/pycrush.py
@@ -1,7 +1,10 @@
-import requests
 import re
+import sys
+import time
+import requests
 
-re_path_template = re.compile('\<\w+\>')
+
+re_path_template = re.compile('<\w+>')
 
 
 class PyCrushException(Exception):
@@ -74,7 +77,7 @@ def bind(**cfg):
 
 
 class API(object):
-    def __init__(self, base='https://mediacru.sh/'):
+    def __init__(self, base='https://imgrush.com/'):
         if base[-1] != "/":
             base += "/"
         self.base = base
@@ -143,7 +146,7 @@ class LazyProperty(object):
 
 class Media(object):
     @classmethod
-    def upload(cls, obj, base='https://mediacru.sh'):
+    def upload(cls, obj, base='https://imgrush.com'):
         api = API(base)
 
         failure_codes = {
@@ -166,7 +169,7 @@ class Media(object):
         if code in failure_codes:
             raise UploadException(failure_codes[code], code)
         if code not in success_codes:
-            raise PyCrushException("MediaCrush returned an unknown code (%s)." % code)
+            raise PyCrushException("Imgrush returned an unknown code (%s)." % code)
 
         result.update({
             'message': success_codes[code],
@@ -177,7 +180,7 @@ class Media(object):
         return cls(**result)
 
     @classmethod
-    def get(cls, hash, base='https://mediacru.sh'):
+    def get(cls, hash, base='https://imgrush.com'):
         api = API(base)
 
         result, code = api.exists(hash=hash)
@@ -191,7 +194,6 @@ class Media(object):
         }
 
         return cls(**params)
-
 
     compression = LazyProperty('compression')
     files = LazyProperty('files')
@@ -215,10 +217,7 @@ class Media(object):
 
 
 if __name__ == '__main__':
-    import sys, time
-
     media = Media.upload(sys.argv[1])
-    # media = Media.get(sys.argv[1])
 
     media.ready_block()
     print media.compression, media.original, media.status

--- a/gfy_mirror/pycrush.py
+++ b/gfy_mirror/pycrush.py
@@ -1,0 +1,224 @@
+import requests
+import re
+
+re_path_template = re.compile('\<\w+\>')
+
+
+class PyCrushException(Exception):
+    pass
+
+
+class SpecificException(PyCrushException):
+    def __init__(self, message, code):
+        super(PyCrushException, self).__init__(self, message)
+        self.code = code
+        self.message = message
+
+
+class UploadException(SpecificException):
+    pass
+
+
+class MediaException(SpecificException):
+    pass
+
+
+class ProcessingException(SpecificException):
+    pass
+
+
+def bind(**cfg):
+    class APIMethod(object):
+        endpoint = cfg['endpoint']  # It's okay to blow up if the endpoint is not provided.
+        method = cfg.get('method', 'GET')
+        required_parameters = cfg.get('parameters', [])
+
+        _args = dict()
+        _request_kwargs = dict()
+
+        def __init__(self, base, params):
+            self._url = base + "api" + self.endpoint
+
+            for v in re_path_template.findall(self._url):
+                name = v.strip('<>')
+                try:
+                    value = params[name]
+                    if isinstance(value, list):
+                        value = ','.join(value)
+                except KeyError:
+                    raise PyCrushException("Variable %r has no value." % name)
+
+                del params[name]  # If we get here it means it's not a POST param and is safe to delete.
+                self._url = self._url.replace(v, value)
+
+            for param in self.required_parameters:
+                if param not in params:
+                    raise PyCrushException("Required parameter %r is not present." % param)
+
+                value = params[param]
+                if param == 'file':
+                    self._request_kwargs['files'] = {param: value}
+                else:
+                    self._args[param] = value
+
+            self._request_kwargs['data'] = self._args
+
+        def run(self):
+            rq = requests.request(self.method, self._url, **self._request_kwargs)
+            return rq.json(), rq.status_code
+
+    def _call(api, **params):  # _call is called as an instance method; i.e, `api` is `self`.
+        return APIMethod(api.base, params).run()
+
+    return _call
+
+
+class API(object):
+    def __init__(self, base='https://mediacru.sh/'):
+        if base[-1] != "/":
+            base += "/"
+        self.base = base
+
+    single = bind(
+        endpoint='/<hash>'
+    )
+    info = bind(
+        endpoint='/info?list=<list>'
+    )
+    exists = bind(
+        endpoint='/<hash>/exists'
+    )
+    delete = bind(
+        endpoint='/<hash>',
+        method='DELETE'
+    )
+    status = bind(
+        endpoint='/<hash>/status'
+    )
+
+    upload_file = bind(
+        endpoint='/upload/file',
+        method='POST',
+        parameters=['file']
+    )
+
+    upload_url = bind(
+        endpoint='/upload/url',
+        method='POST',
+        parameters=['url']
+    )
+
+
+class LazyProperty(object):
+    sources = {
+        'compression': 'single',
+        'files': 'single',
+        'original': 'single',
+        'type': 'single',
+        'status': 'status'
+    }
+
+    bad_statuses = {
+        'processing': 'The file is being processed or is in the queue.',
+        'error': 'The processing step finished early with an abnormal return code.',
+        'timeout': 'The file took too long to process.'
+    }
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, instance, owner):
+        func = getattr(instance.api, self.sources.get(self.name, instance.api.single))
+
+        result, code = func(hash=instance.hash)
+        if code != 200:
+            raise MediaException("The media cannot be found", code)
+
+        instance.populate(result)
+        if self.name != 'status' and instance.status in self.bad_statuses:
+            raise ProcessingException(self.bad_statuses[instance.status], instance.status)
+
+        return result[self.name]
+
+
+class Media(object):
+    @classmethod
+    def upload(cls, obj, base='https://mediacru.sh'):
+        api = API(base)
+
+        failure_codes = {
+            400: 'The URL is invalid.',
+            404: 'The requested file does not exist.',
+            415: 'The file extension is not acceptable.',
+            420: 'The rate limit was exceeded. Enhance your calm.'
+        }
+
+        success_codes = {
+            200: 'The file was uploaded correctly.',
+            409: 'The file was already uploaded.'
+        }
+
+        if isinstance(obj, file):
+            result, code = api.upload_file(file=obj)
+        elif isinstance(obj, str):  # It's a string -> URL.
+            result, code = api.upload_url(url=obj)
+
+        if code in failure_codes:
+            raise UploadException(failure_codes[code], code)
+        if code not in success_codes:
+            raise PyCrushException("MediaCrush returned an unknown code (%s)." % code)
+
+        result.update({
+            'message': success_codes[code],
+            'code': code,
+            'api': api
+        })
+
+        return cls(**result)
+
+    @classmethod
+    def get(cls, hash, base='https://mediacru.sh'):
+        api = API(base)
+
+        result, code = api.exists(hash=hash)
+
+        if code != 200:
+            raise MediaException("The media cannot be found.", code)
+
+        params = {
+            'hash': hash,
+            'api': api,
+        }
+
+        return cls(**params)
+
+
+    compression = LazyProperty('compression')
+    files = LazyProperty('files')
+    original = LazyProperty('original')
+    type = LazyProperty('type')
+
+    status = LazyProperty('status')
+
+    def populate(self, kw):
+        for k, v in kw.items():
+            if k == 'status' and v == 'processing':
+                continue
+            setattr(self, k, v)
+
+    def ready_block(self):
+        while self.status == "processing":
+            time.sleep(1)
+
+    def __init__(self, **kw):
+        self.populate(kw)
+
+
+if __name__ == '__main__':
+    import sys, time
+
+    media = Media.upload(sys.argv[1])
+    # media = Media.get(sys.argv[1])
+
+    media.ready_block()
+    print media.compression, media.original, media.status

--- a/gfy_mirror/utils.py
+++ b/gfy_mirror/utils.py
@@ -70,15 +70,15 @@ def gfycat_convert(url_to_convert):
         return "Error"
 
 
-# Convert to mediacrush
-def mediacrush_convert(url_to_convert):
-    log('--Converting to mediacrush')
+# Convert to imgrush
+def imgrush_convert(url_to_convert):
+    log('--Converting to imgrush')
 
     # Convert
     media = Media()
     response = media.upload(str(url_to_convert))
     log('----success', Color.GREEN)
-    return "https://mediacru.sh/%s" % response.hash
+    return "https://imgrush.com/%s" % response.hash
 
 
 def offsided_convert(title, url_to_convert):

--- a/gfy_mirror/utils.py
+++ b/gfy_mirror/utils.py
@@ -6,6 +6,7 @@ from pyquery import pyquery
 import requests
 import sys
 import subprocess
+from pycrush import Media
 
 __author__ = 'Henri Sweers'
 
@@ -69,14 +70,25 @@ def gfycat_convert(url_to_convert):
         return "Error"
 
 
-def offsided_convert(title, url_to_convert):
-    log('--Converting to offsided')
+# Convert to mediacrush
+# def mediacrush_convert(url_to_convert):
+#     log('--Converting to mediacrush')
+#
+#     # Convert
+#     media = Media()
+#     response = media.upload(str(url_to_convert))
+#     log('----success', Color.GREEN)
+#     return "https://mediacru.sh/%s" % response.hash
+
+
+def fitbamob_convert(title, url_to_convert):
+    log('--Converting to fitbamob')
     req_data = {
         'url': url_to_convert,
         'title': title
     }
     r = requests.post(
-        'http://offsided.com/api/v1/upload-url',
+        'http://fitbamob.com/api/v1/upload-url',
         data=json.dumps(req_data),
         headers={
             'Content-type': 'application/json',
@@ -98,8 +110,8 @@ def offsided_convert(title, url_to_convert):
         return canonical_url
 
 
-def get_offsided_info(f_id):
-    req_url = "http://offsided.com/link/%s" % f_id
+def get_fitbamob_info(f_id):
+    req_url = "http://fitbamob.com/link/%s" % f_id
     r = requests.get(req_url)
     data = r.json()
     return data

--- a/gfy_mirror/utils.py
+++ b/gfy_mirror/utils.py
@@ -71,14 +71,14 @@ def gfycat_convert(url_to_convert):
 
 
 # Convert to mediacrush
-# def mediacrush_convert(url_to_convert):
-#     log('--Converting to mediacrush')
-#
-#     # Convert
-#     media = Media()
-#     response = media.upload(str(url_to_convert))
-#     log('----success', Color.GREEN)
-#     return "https://mediacru.sh/%s" % response.hash
+def mediacrush_convert(url_to_convert):
+    log('--Converting to mediacrush')
+
+    # Convert
+    media = Media()
+    response = media.upload(str(url_to_convert))
+    log('----success', Color.GREEN)
+    return "https://mediacru.sh/%s" % response.hash
 
 
 def fitbamob_convert(title, url_to_convert):

--- a/gfy_mirror/utils.py
+++ b/gfy_mirror/utils.py
@@ -81,14 +81,14 @@ def mediacrush_convert(url_to_convert):
     return "https://mediacru.sh/%s" % response.hash
 
 
-def fitbamob_convert(title, url_to_convert):
-    log('--Converting to fitbamob')
+def offsided_convert(title, url_to_convert):
+    log('--Converting to offsided')
     req_data = {
         'url': url_to_convert,
         'title': title
     }
     r = requests.post(
-        'http://fitbamob.com/api/v1/upload-url',
+        'http://offsided.com/api/v1/upload-url',
         data=json.dumps(req_data),
         headers={
             'Content-type': 'application/json',
@@ -110,8 +110,8 @@ def fitbamob_convert(title, url_to_convert):
         return canonical_url
 
 
-def get_fitbamob_info(f_id):
-    req_url = "http://fitbamob.com/link/%s" % f_id
+def get_offsided_info(f_id):
+    req_url = "http://offsided.com/link/%s" % f_id
     r = requests.get(req_url)
     data = r.json()
     return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-praw==2.1.20
-requests==2.5.3
-pyquery==1.2.9
-python-binary-memcached==0.24.3
-psycopg2==2.6
+praw==2.1.19
+requests==2.3.0
+pyquery==1.2.8
+python-binary-memcached==0.24.2
+psycopg2==2.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-praw==2.1.19
+praw==2.1.20
 requests==2.3.0
 pyquery==1.2.8
 python-binary-memcached==0.24.2

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-2.7.8
+python-2.7.9


### PR DESCRIPTION
This effectively enables imgrush support by simply switching pycrush's endpoints to point to imgrush instead. Imgrush is a fork, so fortunately everything works the same :)
